### PR TITLE
use postgres 11

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ networks:
 
 services:
   db:
-    image: postgres:alpine
+    image: postgres:11-alpine
     restart: on-failure
     environment:
       POSTGRES_USER: "secretboard"


### PR DESCRIPTION
Fixes error that occurred during data transfer: `The data directory was initialized by PostgreSQL version 11, which is not compatible with this version 12.1.`